### PR TITLE
add eqdec fields to the cfg record

### DIFF
--- a/cfg.v
+++ b/cfg.v
@@ -62,6 +62,8 @@ In ss ntl /\
 Record cfg: Type:= {
 start_symbol: non_terminal;
 rules: non_terminal -> sf -> Prop;
+t_eqdec: forall (x y:terminal), {x=y}+{x<>y};
+nt_eqdec: forall (x y:non_terminal), {x=y}+{x<>y};
 rules_finite: exists n: nat,
               exists ntl: nlist,
               exists tl: tlist,

--- a/chomsky.v
+++ b/chomsky.v
@@ -82,6 +82,17 @@ Notation vlist:= (list symbol).
 Inductive non_terminal': Type:=
 | Lift_r: sf -> non_terminal'.
 
+Lemma nt_eqdec':
+ (forall (x y:terminal), {x=y}+{x<>y}) ->
+ (forall (x y:non_terminal), {x=y}+{x<>y}) ->
+ forall (x y:non_terminal'), {x=y}+{x<>y}.
+Proof.
+intros.
+assert (forall (l1 l2:vlist), {l1=l2}+{l1<>l2}).
+ apply list_eq_dec; decide equality.
+decide equality.
+Qed.
+
 Notation sf':= (list (non_terminal' + terminal)).
 Notation ntlist':= (list non_terminal').
 Notation tlist:= (list terminal).
@@ -1117,6 +1128,8 @@ Qed.
 Definition g_cnf (g: cfg non_terminal terminal): cfg non_terminal' terminal := {|
 start_symbol:= Lift_r [inl (start_symbol g)];
 rules:= g_cnf_rules g;
+t_eqdec:= t_eqdec g;
+nt_eqdec:= nt_eqdec' (t_eqdec g) (nt_eqdec g);
 rules_finite:= g_cnf_finite g
 |}.
 
@@ -1186,6 +1199,8 @@ Qed.
 Definition g_cnf' (g: cfg non_terminal terminal) : cfg non_terminal' terminal:= {|
 start_symbol:= start_symbol (g_cnf g);
 rules:= g_cnf'_rules g;
+t_eqdec:= t_eqdec g;
+nt_eqdec:= nt_eqdec' (t_eqdec g) (nt_eqdec g);
 rules_finite:= g_cnf'_finite g
 |}.
 
@@ -2172,7 +2187,11 @@ assert (rf: exists n: nat,
           contradiction.
         }
   }
-exists {| start_symbol:= ss; rules:= rr; rules_finite:= rf |}.
+exists {| start_symbol:= ss; 
+          rules:= rr; 
+          t_eqdec:= t_eqdec g;
+          nt_eqdec:= nt_eqdec' (t_eqdec g) (emptyrules.nt_eqdec' (nt_eqdec g));
+          rules_finite:= rf |}.
 split.
 - apply g_equiv_split. 
   split. 
@@ -2270,7 +2289,11 @@ assert (rf: exists n: nat,
         - inversion H.
         }
   }
-exists {| start_symbol:= ss; rules:= rr; rules_finite:= rf |}.
+exists {| start_symbol:= ss;
+          rules:= rr; 
+          t_eqdec:= t_eqdec g;
+          nt_eqdec:= nt_eqdec' (t_eqdec g) (emptyrules.nt_eqdec' (nt_eqdec g));
+          rules_finite:= rf |}.
 split.
 - unfold g_equiv.
   intros s.

--- a/closure.v
+++ b/closure.v
@@ -37,6 +37,11 @@ Inductive g_clo_nt: Type :=
 | Start_clo : g_clo_nt
 | Transf_clo_nt : non_terminal -> g_clo_nt.
 
+Lemma nt_eqdec':
+ (forall x y: non_terminal, {x=y}+{x<>y}) ->
+ (forall x y: g_clo_nt, {x=y}+{x<>y}).
+Proof. decide equality. Qed.
+
 Notation sf:= (list (non_terminal + terminal)).
 Notation sfc:= (list (g_clo_nt + terminal)).
 Notation nlist:= (list g_clo_nt).
@@ -258,6 +263,8 @@ Qed.
 Definition g_clo (g: cfg non_terminal terminal): (cfg g_clo_nt terminal):= {|
 start_symbol:= Start_clo;
 rules:= g_clo_rules g;
+t_eqdec:= t_eqdec g;
+nt_eqdec:= nt_eqdec' (nt_eqdec g);
 rules_finite:= g_clo_finite g
 |}.
 

--- a/concatenation.v
+++ b/concatenation.v
@@ -38,6 +38,12 @@ Inductive g_cat_nt: Type:=
 | Transf1_cat_nt: non_terminal_1 -> g_cat_nt
 | Transf2_cat_nt: non_terminal_2 -> g_cat_nt.
 
+Lemma nt_eqdec':
+ (forall x y: non_terminal_1, {x=y}+{x<>y}) -> 
+ (forall x y: non_terminal_2, {x=y}+{x<>y}) -> 
+ (forall x y: g_cat_nt, {x=y}+{x<>y}).
+Proof. decide equality. Qed.
+
 Notation sf1:= (list (non_terminal_1 + terminal)).
 Notation sf2:= (list (non_terminal_2 + terminal)).
 Notation sfc:= (list (g_cat_nt + terminal)).
@@ -451,6 +457,8 @@ Qed.
 Definition g_cat (g1: cfg non_terminal_1 terminal) (g2: cfg non_terminal_2 terminal): (cfg g_cat_nt terminal):= {|
 start_symbol:= Start_cat;
 rules:= g_cat_rules g1 g2;
+t_eqdec:= t_eqdec g1;
+nt_eqdec:= nt_eqdec' (nt_eqdec g1) (nt_eqdec g2);
 rules_finite:= g_cat_finite g1 g2
 |}.
 

--- a/emptyrules.v
+++ b/emptyrules.v
@@ -46,6 +46,12 @@ Inductive non_terminal': Type:=
 | Lift_nt: non_terminal -> non_terminal'
 | New_ss. 
 
+
+Lemma nt_eqdec' : 
+ (forall (x y: non_terminal), {x=y}+{x<>y}) ->
+ forall (x y: non_terminal'), {x=y}+{x<>y}.
+Proof. decide equality. Qed.
+
 Notation symbol:= (non_terminal + terminal)%type.
 Notation symbol':= (non_terminal' + terminal)%type.
 Notation nlist:= (list non_terminal).
@@ -319,6 +325,8 @@ Qed.
 Definition g_emp (g: cfg non_terminal terminal): cfg non_terminal' terminal := {|
 start_symbol:= New_ss;
 rules:= g_emp_rules g;
+t_eqdec:= t_eqdec g;
+nt_eqdec:= nt_eqdec' (nt_eqdec g);
 rules_finite:= g_emp_finite g
 |}.
 
@@ -2042,6 +2050,8 @@ Qed.
 Definition g_emp' (g: cfg non_terminal terminal): cfg (non_terminal' _) terminal := {|
 start_symbol:= New_ss _;
 rules:= g_emp'_rules g;
+t_eqdec:= t_eqdec g;
+nt_eqdec:= nt_eqdec' (nt_eqdec g);
 rules_finite:= g_emp'_finite g
 |}.
 
@@ -3064,7 +3074,7 @@ revert Heqw2.
 revert Heqw1.
 revert n.
 induction H.
-- admit. (* eee *)
+- intros n H; rewrite H; intros E; discriminate E.
 - admit. (* eee *)
 Qed.
 

--- a/inaccessible.v
+++ b/inaccessible.v
@@ -88,6 +88,8 @@ Qed.
 Definition g_acc (g: cfg _ _): cfg _ _ := {|
 start_symbol:= start_symbol g;
 rules:= g_acc_rules g;
+t_eqdec:= t_eqdec g;
+nt_eqdec:= nt_eqdec g;
 rules_finite:= g_acc_finite g
 |}.
 

--- a/pumping.v
+++ b/pumping.v
@@ -575,6 +575,7 @@ apply lang_eq_change_g with (non_terminal':= chomsky.non_terminal' (emptyrules.n
             - repeat rewrite <- app_assoc. 
               exact H20copy.
             }
+        + apply (nt_eqdec g').
         + rewrite H28.
           exact H24'.
       - apply cnf_bnts with (g:= g') (n:= n') (tl:= tl').
@@ -756,7 +757,7 @@ apply lang_eq_change_g with (non_terminal':= chomsky.non_terminal' (emptyrules.n
             left.
             reflexivity.
           }
-        apply pigeon in H29. 
+        apply pigeon in H29.
         + destruct H29 as [n [r1' [r2' [r3' H29]]]].
           rewrite H29 in H27.
           repeat rewrite map_app in H27.
@@ -1014,6 +1015,7 @@ apply lang_eq_change_g with (non_terminal':= chomsky.non_terminal' (emptyrules.n
             - repeat rewrite <- app_assoc. 
               exact H20copy.
             }
+        + apply (nt_eqdec g').
         + rewrite H28.
           exact H24'.
       - apply cnf_bnts with (g:= g') (n:= n') (tl:= tl').

--- a/union.v
+++ b/union.v
@@ -38,6 +38,12 @@ Inductive g_uni_nt: Type:=
 | Transf1_uni_nt: non_terminal_1 -> g_uni_nt
 | Transf2_uni_nt: non_terminal_2 -> g_uni_nt.
 
+Lemma nt_eqdec':
+ (forall x y:non_terminal_1, {x=y}+{x<>y}) ->
+ (forall x y:non_terminal_2, {x=y}+{x<>y}) ->
+ (forall x y:g_uni_nt, {x=y}+{x<>y}).
+Proof. decide equality. Qed.
+
 Notation sf1:= (list (non_terminal_1 + terminal)).
 Notation sf2:= (list (non_terminal_2 + terminal)).
 Notation sfu:= (list (g_uni_nt + terminal)).
@@ -463,6 +469,8 @@ Qed.
 Definition g_uni (g1: cfg non_terminal_1 terminal) (g2: cfg non_terminal_2 terminal): (cfg g_uni_nt terminal):= {|
 start_symbol:= Start_uni;
 rules:= g_uni_rules g1 g2;
+t_eqdec:= t_eqdec g1;
+nt_eqdec:= nt_eqdec' (nt_eqdec g1) (nt_eqdec g2);
 rules_finite:= g_uni_finite g1 g2
 |}.
 

--- a/unitrules.v
+++ b/unitrules.v
@@ -150,6 +150,8 @@ Qed.
 Definition g_unit (g: cfg _ _): cfg _ _ := {|
 start_symbol:= start_symbol g;
 rules:= g_unit_rules g;
+t_eqdec:= t_eqdec g;
+nt_eqdec:= nt_eqdec g;
 rules_finite:= g_unit_finite g
 |}.
 

--- a/useless.v
+++ b/useless.v
@@ -99,6 +99,8 @@ Qed.
 Definition g_use (g: cfg _ _): cfg _ _:= {|
 start_symbol:= start_symbol g;
 rules:= g_use_rules g;
+t_eqdec:= t_eqdec g;
+nt_eqdec:= nt_eqdec g;
 rules_finite:= g_use_finite g
 |}.
 


### PR DESCRIPTION
Caro Marcus,

adicionei os campos que requerem a decidibilidade da igualdade na definição de CFG. Todo o desenvolvimento foi ajustado para incorporar esses campos nas várias transformações.
Assim, a prova do pigeon principle (e por consequência o pumping lemma) já não necessitam de qualquer axioma clássico.

abr,
bac

PS: reparei que nos ficheiros allrules.v e emptyrules.v ainda persistem uns admits...
